### PR TITLE
use 84codes images for aarch64, and fix crystallang version to 1.11

### DIFF
--- a/build/ahk_x11.alpine.Dockerfile
+++ b/build/ahk_x11.alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:latest-alpine AS build-ahkx11
+FROM --platform=linux/arm64 84codes/crystal:1.11.2-alpine AS build-ahkx11
 RUN apk add --no-cache gtk+3.0-dev gobject-introspection-dev libxtst-dev libnotify-dev alpine-sdk libxinerama-dev libxkbcommon-dev libx11-dev
 RUN git clone --depth=1 https://github.com/phil294/ahk_x11 /ahk
 WORKDIR /ahk


### PR DESCRIPTION
Resolving the version and platform issues of crystallang, as mentioned in [107](https://github.com/phil294/AHK_X11/issues/107)